### PR TITLE
Fix for Issue 42 requesting post notification on Android 13

### DIFF
--- a/app/src/main/java/com/polar/nextcloudservices/SettingsActivity.java
+++ b/app/src/main/java/com/polar/nextcloudservices/SettingsActivity.java
@@ -238,12 +238,12 @@ public class SettingsActivity extends AppCompatActivity implements SharedPrefere
 
     public void requestNotificationPermission() {
         if(Build.VERSION.SDK_INT >= 33) {
-            if (ContextCompat.checkSelfPermission(this, Manifest.permission.ACCESS_NOTIFICATION_POLICY) == PackageManager.PERMISSION_GRANTED) {
+            if (ContextCompat.checkSelfPermission(this, Manifest.permission.POST_NOTIFICATIONS) == PackageManager.PERMISSION_GRANTED) {
                 Log.d(TAG, "Notification permission is granted.");
                 return;
             }
             Log.d(TAG, "Notification permission is not granted yet, so will request it now");
-            ActivityCompat.requestPermissions(this, new String[]{Manifest.permission.ACCESS_NOTIFICATION_POLICY}, NOTIFICATION_PERMISSION_CODE);
+            ActivityCompat.requestPermissions(this, new String[]{Manifest.permission.POST_NOTIFICATIONS}, NOTIFICATION_PERMISSION_CODE);
         }
     }
 


### PR DESCRIPTION
Fixed Issue 42 requesting post notification on Android 13 devices. The permission requested should be POST_NOTIFICATIONS. Tested on LOS 20.0.