### PR TITLE
Fix for Issue#49

### DIFF
--- a/app/src/main/java/com/polar/nextcloudservices/Notification/Processors/ActionsNotificationProcessor.java
+++ b/app/src/main/java/com/polar/nextcloudservices/Notification/Processors/ActionsNotificationProcessor.java
@@ -39,7 +39,7 @@ public class ActionsNotificationProcessor implements AbstractNotificationProcess
             intent.putExtra("notification_event", NOTIFICATION_EVENT_CUSTOM_ACTION);
             String link = action.getString("link");
             final String type = action.getString("type");
-            link = Util.cleanUpURLIfNeeded(service.server, link);
+            link = Util.cleanUpURLIfNeeded(link);
             Log.d(TAG, link);
             Log.d(TAG, type);
             intent.putExtra("action_link", link);

--- a/app/src/main/java/com/polar/nextcloudservices/Util.java
+++ b/app/src/main/java/com/polar/nextcloudservices/Util.java
@@ -1,8 +1,14 @@
 package com.polar.nextcloudservices;
 
 import android.content.pm.PackageManager;
+import android.util.Log;
+
+import java.net.URI;
+import java.net.URISyntaxException;
 
 public class Util {
+    private static final String TAG = "Util";
+
     public static boolean isPackageInstalled(String packageName, PackageManager packageManager) {
         try {
             packageManager.getPackageInfo(packageName, 0);
@@ -13,22 +19,30 @@ public class Util {
     }
 
     /**
-     * Clean-ups URL by removing domain and protocl if needed
-     * Example: "https://cloud.example.com/query" -> "/query"
-     * @param domain Domain of a service
-     * @param target Target URL to remove a domain from
+     * Clean-ups URL by removing domain and protocol if needed
+     * according to wikipedia a uniform resource locator is composed of the following elements:
+     * URI = scheme ":" ["//" authority] path ["?" query] ["#" fragment]
+     * authority = [userinfo "@"] host [":" port]
+     *
+     * Example: "https://cloud.example.com/path?query#fragment" -> "/path?query#fragment"
+     * @param target Target URL to remove everything in front of the path
      * @return String cleaned-up from protocol and domain
      */
-    public static String cleanUpURLIfNeeded(String domain, String target){
-        if(target.startsWith("http://")){
-            target = target.replaceFirst("http://", "");
+   public static String cleanUpURLIfNeeded(String target){
+        try {
+            URI uri = new URI(target);
+            String result = uri.getPath().toString();
+            if(uri.getQuery() != null) {
+                result = result + "?" + uri.getQuery().toString();
+            }
+            if(uri.getFragment() != null) {
+                result = result + "#" + uri.getFragment().toString();
+            }
+            return result;
+        } catch (URISyntaxException e) {
+            Log.e(TAG, "error cleaning up target link.");
+            e.printStackTrace();
+            return null;
         }
-        if(target.startsWith("https://")){
-            target = target.replaceFirst("https://", "");
-        }
-        if(target.startsWith(domain)){
-            target = target.replaceFirst(domain, "");
-        }
-        return target;
     }
 }

--- a/app/src/test/java/com/polar/nextcloudservices/UtilTest.java
+++ b/app/src/test/java/com/polar/nextcloudservices/UtilTest.java
@@ -10,14 +10,16 @@ import static org.junit.Assert.*;
 public class UtilTest {
     @Test
     public void testURLCleanup(){
-        String result1 = Util.cleanUpURLIfNeeded("cloud.example.com",
-                "https://cloud.example.com/query?domain=cloud.example.com&path=https://cloud");
+        String result1 = Util.cleanUpURLIfNeeded("https://cloud.example.com/query?domain=cloud.example.com&path=https://cloud");
         assertEquals(result1, "/query?domain=cloud.example.com&path=https://cloud");
-        String result2 = Util.cleanUpURLIfNeeded("cloud.example.com",
-                "cloud.example.com/query?domain=cloud.example.com&path=https://cloud");
-        assertEquals(result2, "/query?domain=cloud.example.com&path=https://cloud");
-        String result3 = Util.cleanUpURLIfNeeded("cloud.example.com",
-                "https://cloud.example.com/query?domain=cloud.example.com&path=https://cloud");
+        String result3 = Util.cleanUpURLIfNeeded("https://cloud.example.com/query?domain=cloud.example.com&path=https://cloud");
         assertEquals(result3, "/query?domain=cloud.example.com&path=https://cloud");
+
+        String result4 = Util.cleanUpURLIfNeeded("https://cloud.example.com:8080/query");
+        assertEquals(result4, "/query");
+        String result5 = Util.cleanUpURLIfNeeded("https://cloud.example.com:8080/query?domain=cloud.example.com&path=https://cloud");
+        assertEquals(result5, "/query?domain=cloud.example.com&path=https://cloud");
+        String result6 = Util.cleanUpURLIfNeeded("https://cloud.example.com:8080/query?domain=cloud.example.com&path=https://cloud#fragment");
+        assertEquals(result6, "/query?domain=cloud.example.com&path=https://cloud#fragment");
     }
 }


### PR DESCRIPTION
Bugfix for cleanUpURLIfNeeded to remove everything in front of the path. This will allow using links provided by actions using SSO login option without having to specify the domain in the settings. This should work (but still has to be tested) for the username/password login method as well since the domain is given by the link itself.
I also removed the result2 test in the UtilTest.java since using the link the protocol is always provided.